### PR TITLE
more fiat support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amountinator",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amountinator",
-      "version": "0.2.13",
+      "version": "0.2.14",
       "license": "Open BSV License",
       "dependencies": {
         "@bsv/sdk": "^2.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Open BSV License",
       "dependencies": {
         "@bsv/sdk": "^2.0.4",
-        "@bsv/wallet-toolbox-client": "^2.0.19"
+        "@bsv/wallet-toolbox-client": "^2.0.20"
       },
       "devDependencies": {
         "@types/jest": "^29.5.12",
@@ -514,9 +514,9 @@
       "license": "SEE LICENSE IN LICENSE.txt"
     },
     "node_modules/@bsv/wallet-toolbox-client": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/@bsv/wallet-toolbox-client/-/wallet-toolbox-client-2.0.19.tgz",
-      "integrity": "sha512-Qtzbi6JrHysWK/Pc0P3oZgmH7MWN3ITaq3g/YzVUWFF7WIFXgBzVCE35crcOo6ygdOsxEjaAclP4MKytlkBqQA==",
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/@bsv/wallet-toolbox-client/-/wallet-toolbox-client-2.0.20.tgz",
+      "integrity": "sha512-vK6C99ta5YI0LsCPaRXtz6XXJsn8qjCjaAaDktxFolOkUjkQySNMxqWTtnSzr895CRymTaCihFJp2RuQDM7A3A==",
       "license": "SEE LICENSE IN license.md",
       "dependencies": {
         "@bsv/sdk": "^2.0.0",
@@ -1754,6 +1754,21 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
   },
   "dependencies": {
     "@bsv/sdk": "^2.0.4",
-    "@bsv/wallet-toolbox-client": "^2.0.19"
+    "@bsv/wallet-toolbox-client": "^2.0.20"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amountinator",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "Currency amount conversion",
   "author": "Peer-to-peer Privacy Systems Research, LLC",
   "license": "Open BSV License",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,28 @@
+export const SUPPORTED_FIAT_CURRENCY_CODES = [
+  'USD',
+  'EUR',
+  'GBP',
+  'JPY',
+  'CNY',
+  'INR',
+  'AUD',
+  'CAD',
+  'CHF',
+  'HKD',
+  'SGD',
+  'NZD',
+  'SEK',
+  'NOK',
+  'MXN'
+] as const
+
+export type FiatCurrencyCode = (typeof SUPPORTED_FIAT_CURRENCY_CODES)[number]
+
+export type SupportedCurrencyCode = FiatCurrencyCode | 'BSV' | 'SATS'
+
 export interface ExchangeRates {
   usdPerBsv: number
-  gbpPerUsd: number
-  eurPerUsd: number
+  fiatPerUsd: Record<FiatCurrencyCode, number>
 }
 
 export interface FormatOptions {

--- a/src/utils/amountFormatHelpers.ts
+++ b/src/utils/amountFormatHelpers.ts
@@ -50,18 +50,36 @@ export function formatAmountWithCurrency(amount: number, currency: string, optio
   let formattedAmount = decimalPart ? `${integerPart}.${decimalPart}` : integerPart
 
   // Prepare the currency symbol or suffix
-  const symbols: Record<string, string> = { USD: '$', GBP: '£', EUR: '€' }
+  const symbols: Record<string, string> = {
+    USD: '$',
+    GBP: '£',
+    EUR: '€',
+    JPY: '¥',
+    CNY: '¥',
+    INR: '₹',
+    AUD: 'A$',
+    CAD: 'C$',
+    CHF: 'CHF ',
+    HKD: 'HK$',
+    SGD: 'S$',
+    NZD: 'NZ$',
+    SEK: 'SEK ',
+    NOK: 'NOK ',
+    MXN: 'MX$'
+  }
   formattedAmount =
     currency === 'SATS' || currency === 'BSV'
       ? formattedAmount + (currency === 'SATS' ? ' satoshis' : ' BSV')
-      : (symbols[currency] || '') + formattedAmount
+      : (symbols[currency] || `${currency} `) + formattedAmount
 
   // build result with hover text
   const result: { formattedAmount: string; hoverText?: string } = { formattedAmount }
   if (amount < 0.01) {
     result.hoverText = formattedAmount
     result.formattedAmount =
-      currency === 'BSV' ? `< 0.01 BSV` : `< ${(symbols[currency] || '')}0.01`
+      currency === 'BSV'
+        ? `< 0.01 BSV`
+        : `< ${(symbols[currency] || `${currency} `)}0.01`
   }
 
   return result

--- a/tests/currencyConverterCache.test.ts
+++ b/tests/currencyConverterCache.test.ts
@@ -2,12 +2,12 @@ import { CurrencyConverter } from '../src/utils/currencyConverter'
 import { formatAmountWithCurrency } from '../src/utils/amountFormatHelpers'
 
 const getBsvExchangeRateMock = jest.fn()
-const getFiatExchangeRateMock = jest.fn()
+const getFiatExchangeRatesMock = jest.fn()
 
 jest.mock('@bsv/wallet-toolbox-client', () => ({
     Services: jest.fn().mockImplementation(() => ({
         getBsvExchangeRate: getBsvExchangeRateMock,
-        getFiatExchangeRate: getFiatExchangeRateMock
+        getFiatExchangeRates: getFiatExchangeRatesMock
     }))
 }))
 
@@ -31,7 +31,11 @@ describe('CurrencyConverter cache behaviour', () => {
             .mockResolvedValue(100)
 
         // fiat rates are fine staying constant for this test
-        getFiatExchangeRateMock.mockResolvedValue(1)
+        getFiatExchangeRatesMock.mockResolvedValue({
+            timestamp: new Date(),
+            base: 'USD',
+            rates: {}
+        })
     })
 
     afterEach(() => {


### PR DESCRIPTION
- Added support for all of the types of fiat currency that wallet-toolbox supports, including: JPY, CNY, INR, AUD, CAD, CHF, HKD, SGD, NZD, SEK, NOK, and MXN